### PR TITLE
Refactored to use handles for head and tail allowing for smoother tra…

### DIFF
--- a/cppdigraph.ctags
+++ b/cppdigraph.ctags
@@ -49,6 +49,8 @@ Edge	src/edge.h	/^  Edge(tail_t& tail$/;"	f	class:cdg::Edge
 Edge	src/edge.h	/^class Edge {$/;"	c	namespace:cdg
 HEX	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^#define HEX(/;"	d	file:
 HEX	CMakeFiles/3.0.2/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define HEX(/;"	d	file:
+Head	src/edge.h	/^  Head(Edge<tail_t, head_t>* edge): mEdge(edge) {}$/;"	f	class:cdg::Head
+Head	src/edge.h	/^class Head {$/;"	c	namespace:cdg
 ID_VOID_MAIN	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^# define ID_VOID_MAIN$/;"	d	file:
 Node	src/node.h	/^  Node(std::string name): mName(name) {}$/;"	f	class:cdg::Node
 Node	src/node.h	/^class Node {$/;"	c	namespace:cdg
@@ -70,6 +72,8 @@ SIMULATE_VERSION_MINOR	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^#  defi
 SIMULATE_VERSION_MINOR	CMakeFiles/3.0.2/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_MINOR /;"	d	file:
 SUFFIXES	Makefile	/^SUFFIXES =$/;"	m
 SUFFIXES	src/Makefile	/^SUFFIXES =$/;"	m
+Tail	src/edge.h	/^  Tail(Edge<tail_t, head_t>* edge): mEdge(edge) {}$/;"	f	class:cdg::Tail
+Tail	src/edge.h	/^class Tail {$/;"	c	namespace:cdg
 all	Makefile	/^all: cmake_check_build_system$/;"	t
 all	src/Makefile	/^all: cmake_check_build_system$/;"	t
 cdg	src/edge.h	/^namespace cdg {$/;"	n
@@ -90,6 +94,8 @@ edit_cache	Makefile	/^edit_cache:$/;"	t
 edit_cache	src/Makefile	/^edit_cache:$/;"	t
 edit_cache/fast	Makefile	/^edit_cache\/fast: edit_cache$/;"	t
 edit_cache/fast	src/Makefile	/^edit_cache\/fast: edit_cache$/;"	t
+getEdge	src/edge.h	/^  Edge<tail_t, head_t>* getEdge() { return mEdge; }$/;"	f	class:cdg::Head	typeref:typename:Edge<tail_t,head_t> *
+getEdge	src/edge.h	/^  Edge<tail_t, head_t>* getEdge() { return mEdge; }$/;"	f	class:cdg::Tail	typeref:typename:Edge<tail_t,head_t> *
 getHead	src/edge.h	/^  head_t& getHead() { return *mHead; }$/;"	f	class:cdg::Edge	typeref:typename:head_t &
 getName	src/edge.h	/^  const std::string getName() const { return mName; }$/;"	f	class:cdg::Edge	typeref:typename:const std::string
 getName	src/node.h	/^  const std::string getName() const { return mName; }$/;"	f	class:cdg::Node	typeref:typename:const std::string
@@ -108,10 +114,14 @@ info_simulate_version	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^char con
 info_simulate_version	CMakeFiles/3.0.2/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_simulate_version[] = {$/;"	v	typeref:typename:char const[]
 info_version	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^char const info_version[] = {$/;"	v	typeref:typename:char const[]
 info_version	CMakeFiles/3.0.2/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_version[] = {$/;"	v	typeref:typename:char const[]
+mEdge	src/edge.h	/^  Edge<tail_t, head_t>* mEdge;$/;"	m	class:cdg::Head	typeref:typename:Edge<tail_t,head_t> *
+mEdge	src/edge.h	/^  Edge<tail_t, head_t>* mEdge;$/;"	m	class:cdg::Tail	typeref:typename:Edge<tail_t,head_t> *
 mHead	src/edge.h	/^  head_t* mHead;$/;"	m	class:cdg::Edge	typeref:typename:head_t *
+mHeadHandle	src/edge.h	/^  Head<tail_t, head_t> mHeadHandle;$/;"	m	class:cdg::Edge	typeref:typename:Head<tail_t,head_t>
 mName	src/edge.h	/^  const std::string mName;$/;"	m	class:cdg::Edge	typeref:typename:const std::string
 mName	src/node.h	/^  const std::string mName;$/;"	m	class:cdg::Node	typeref:typename:const std::string
 mTail	src/edge.h	/^  tail_t* mTail;$/;"	m	class:cdg::Edge	typeref:typename:tail_t *
+mTailHandle	src/edge.h	/^  Tail<tail_t, head_t> mTailHandle;$/;"	m	class:cdg::Edge	typeref:typename:Tail<tail_t,head_t>
 main	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^int main(int argc, char* argv[])$/;"	f	typeref:typename:int
 main	CMakeFiles/3.0.2/CompilerIdC/CMakeCCompilerId.c	/^void main() {}$/;"	f	typeref:typename:void
 main	CMakeFiles/3.0.2/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^int main(int argc, char* argv[])$/;"	f	typeref:typename:int
@@ -141,6 +151,8 @@ src/test.o	Makefile	/^src\/test.o: src\/test.cpp.o$/;"	t
 src/test.s	Makefile	/^src\/test.s: src\/test.cpp.s$/;"	t
 test.out	Makefile	/^test.out: cmake_check_build_system$/;"	t
 test.out/fast	Makefile	/^test.out\/fast:$/;"	t
+traverse	src/edge.h	/^  head_t& traverse() { return mEdge->getHead(); }$/;"	f	class:cdg::Tail	typeref:typename:head_t &
+traverse	src/edge.h	/^  tail_t& traverse() { return mEdge->getTail(); }$/;"	f	class:cdg::Head	typeref:typename:tail_t &
 ~Edge	src/edge.h	/^  ~Edge() {$/;"	f	class:cdg::Edge
 ~NodeA	src/test.cpp	/^  ~NodeA() {$/;"	f	class:NodeA	file:
 ~NodeB	src/test.cpp	/^  ~NodeB() {$/;"	f	class:NodeB	file:

--- a/src/edge.h
+++ b/src/edge.h
@@ -1,8 +1,10 @@
 /*
- * Edge
- *   Base class for edges.  Templated with the endpoint types
- *   so that the head and tail are fully resolved when the edge
- *   is traversed.
+ * edeg.h
+ *
+ * Types:
+ *   Tail - Handle to tail of an edge.
+ *   Head - Handle to head of an edge.
+ *   Edge - The edge itself.
  */
  
 #ifndef CDG_EDGE_H
@@ -14,6 +16,51 @@
 namespace cdg {
 
 
+template <typename tail_t, typename head_t> class Edge;
+
+/*
+ * Tail
+ *   Handle for the tail of an edge used to implement a type
+ *   aware `traverse` method.
+ */
+template <typename tail_t, typename head_t>
+class Tail {
+public:
+  Tail(Edge<tail_t, head_t>* edge): mEdge(edge) {}
+
+  head_t& traverse() { return mEdge->getHead(); }
+  Edge<tail_t, head_t>* getEdge() { return mEdge; }
+
+private:
+  Edge<tail_t, head_t>* mEdge;
+
+};
+
+
+/*
+ * Head
+ *   Handle for the head of an edge used to implement a type
+ *   aware `traverse` method.
+ */
+template <typename tail_t, typename head_t>
+class Head {
+public:
+  Head(Edge<tail_t, head_t>* edge): mEdge(edge) {}
+
+  tail_t& traverse() { return mEdge->getTail(); }
+  Edge<tail_t, head_t>* getEdge() { return mEdge; }
+
+private:
+  Edge<tail_t, head_t>* mEdge;
+
+};
+
+
+/*
+ * Edge
+ *   Templated with the endpoint types so that the head and
+ *   tail are fully resolved when the edge is traversed.
+ */
 template <typename tail_t, typename head_t>
 class Edge {
 public:
@@ -22,14 +69,16 @@ public:
     ): mName(tail.getName() + "->" + head.getName())
      , mTail(&tail)
      , mHead(&head)
+     , mTailHandle(this)
+     , mHeadHandle(this)
   {
-    tail.connectTail(this);
-    head.connectHead(this);
+    mTail->connectTail(&mTailHandle);
+    mHead->connectHead(&mHeadHandle);
   }
 
   ~Edge() {
-    mTail->destructTail(this);
-    mHead->destructHead(this);
+    mTail->destructTail(&mTailHandle);
+    mHead->destructHead(&mHeadHandle);
   }
 
   const std::string getName() const { return mName; }
@@ -41,7 +90,11 @@ private:
   tail_t* mTail;
   head_t* mHead;
 
+  Tail<tail_t, head_t> mTailHandle;
+  Head<tail_t, head_t> mHeadHandle;
+
 };
+
 
 } // namespace cdg
 

--- a/src/node.h
+++ b/src/node.h
@@ -31,22 +31,22 @@ namespace cdg {
 // set<Edge<B, A>*> A::mBAHeads
 #define CDG_NODE_CREATE_RELATIONSHIP(__this, __that, __tails_name, __heads_name) \
 public: \
-  void connectTail(cdg::Edge<__this, __that>* edge) { __tails_name.insert(edge); } \
-  void connectHead(cdg::Edge<__that, __this>* edge) { __heads_name.insert(edge); } \
-  void destructTail(cdg::Edge<__this, __that>* edge) { __tails_name.erase(edge); } \
-  void destructHead(cdg::Edge<__that, __this>* edge) { __heads_name.erase(edge); } \
+  void connectTail(cdg::Tail<__this, __that>* edge) { __tails_name.insert(edge); } \
+  void connectHead(cdg::Head<__that, __this>* edge) { __heads_name.insert(edge); } \
+  void destructTail(cdg::Tail<__this, __that>* edge) { __tails_name.erase(edge); } \
+  void destructHead(cdg::Head<__that, __this>* edge) { __heads_name.erase(edge); } \
  \
 private: \
-  std::set<cdg::Edge<__this, __that>*> __tails_name; \
-  std::set<cdg::Edge<__that, __this>*> __heads_name;
+  std::set<cdg::Tail<__this, __that>*> __tails_name; \
+  std::set<cdg::Head<__that, __this>*> __heads_name;
 // end CDG_NODE_CREATE_RELATIONSHIP
 
 
 // Optional automatic edge deletion for a named collection.
 //   This macro should be placed in the User Node class destructor.
-#define CDG_NODE_DESTRUCT_RELATIONSHIP(__edge_collection) \
-for (auto& edge : __edge_collection) delete edge; \
-__edge_collection.clear();
+#define CDG_NODE_DESTRUCT_RELATIONSHIP(__collection) \
+for (auto& handle : __collection) delete handle->getEdge(); \
+__collection.clear();
 // end CDG_NODE_DESTRUCT_RELATIONSHP
 
 /*

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -33,8 +33,8 @@ public:
   }
 
   void printUpstreamAs() {
-    for (auto& edge : mAAHeads) {
-      edge->getTail().printUpstreamAs();
+    for (auto& head : mAAHeads) {
+      head->traverse().printUpstreamAs();
     }
     if (mAAHeads.size() > 0) cout << " -> ";
     this->operator<<(cout);
@@ -43,8 +43,8 @@ public:
   void printDownstreamAs() {
     this->operator<<(cout);
     if (mAATails.size() > 0) cout << " -> ";
-    for (auto& edge : mAATails) {
-      edge->getHead().printDownstreamAs();
+    for (auto& tail : mAATails) {
+      tail->traverse().printDownstreamAs();
     }
   }
 
@@ -68,14 +68,14 @@ public:
   }
 
   void printAs() {
-    for (auto& edge : mABHeads) {
-      edge->getTail().printUpstreamAs();
+    for (auto& head : mABHeads) {
+      head->traverse().printUpstreamAs();
     }
     if (mABHeads.size() > 0) cout << " -> ";
     this->operator<<(cout);
     if (mBATails.size() > 0) cout << " -> ";
-    for (auto& edge : mBATails) {
-      edge->getHead().printDownstreamAs();
+    for (auto& tail : mBATails) {
+      tail->traverse().printDownstreamAs();
     }
   }
 


### PR DESCRIPTION
…versal API: i.e. mHead->traverse() gets the tail pointer, instead of mHead->getTail() and mTail->getHead().